### PR TITLE
Add deletion request feature

### DIFF
--- a/web/sql/schema.sql
+++ b/web/sql/schema.sql
@@ -48,6 +48,18 @@ create table if not exists audit_log (
   created_at timestamptz default now()
 );
 
+-- Deletion Requests: allow anyone to request a case be deleted
+create table if not exists deletion_requests (
+  id uuid primary key default gen_random_uuid(),
+  submission_id uuid references submissions(id) on delete cascade,
+  reason text not null,
+  requester text, -- optional: email, ip hash, or name if provided
+  created_at timestamptz default now()
+);
+
+-- indexes for faster lookups
+create index if not exists deletion_requests_submission_idx on deletion_requests(submission_id);
+
 -- RLS (to enable in Supabase)
 -- alter table submissions enable row level security;
 -- create policy public_read_only on submissions for select using (public = true);

--- a/web/src/app/api/cases/[id]/request-deletion/route.ts
+++ b/web/src/app/api/cases/[id]/request-deletion/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseServer } from "@/lib/supabase-server";
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+  try {
+    const body = await req.json().catch(() => ({}));
+    const reasonRaw = (body?.reason ?? "");
+    const requesterRaw = (body?.requester ?? null);
+    const reason = typeof reasonRaw === "string" ? reasonRaw.trim() : "";
+    const requester = typeof requesterRaw === "string" ? requesterRaw.slice(0, 200) : null;
+    if (!reason) {
+      return NextResponse.json({ error: "Reason is required" }, { status: 400 });
+    }
+
+    const supabase = getSupabaseServer();
+    // Verify the submission exists (optional but nice)
+    const { data: sub, error: subErr } = await supabase
+      .from("submissions")
+      .select("id")
+      .eq("id", id)
+      .limit(1);
+    if (subErr) throw subErr;
+    if (!sub || sub.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const { data, error } = await supabase
+      .from("deletion_requests")
+      .insert({ submission_id: id, reason, requester })
+      .select("id, created_at")
+      .limit(1);
+    if (error) throw error;
+
+    // Soft-hide immediately: set public=false
+    const { error: updErr } = await supabase
+      .from("submissions")
+      .update({ public: false })
+      .eq("id", id);
+    if (updErr) throw updErr;
+
+    // Log to audit_log for transparency (actor=anonymous)
+    await supabase
+      .from("audit_log")
+      .insert({
+        actor: "anonymous",
+        action: "request_deletion",
+        submission_id: id,
+        payload: { reason, requester },
+      });
+
+    return NextResponse.json({ ok: true, id: data?.[0]?.id ?? null });
+  } catch (err) {
+    console.error("/api/cases/[id]/request-deletion error", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+

--- a/web/src/app/api/cases/route.ts
+++ b/web/src/app/api/cases/route.ts
@@ -25,6 +25,9 @@ export async function GET(req: NextRequest) {
       .select("id, created_at, sender_id, sender_name, raw_text", { count: "exact" })
       .order("created_at", { ascending: false });
 
+    // Only show public cases
+    builder = builder.eq("public", true);
+
     if (q.length > 0) {
       const sanitized = q.replace(/[%]/g, "").replace(/,/g, " ");
       builder = builder.or(`sender_name.ilike.%${sanitized}%,sender_id.ilike.%${sanitized}%`);

--- a/web/src/app/cases/[id]/page.tsx
+++ b/web/src/app/cases/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { LiveViolations, LiveSender, LiveSummary } from "./client";
+import { LiveViolations, LiveSender, LiveSummary, RequestDeletionButton } from "./client";
 import LocalTime from "@/components/LocalTime";
 type CaseItem = {
   id: string;
@@ -39,6 +39,7 @@ export default async function CaseDetailPage({ params }: { params: Promise<{ id:
   const imgRes = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL || ""}/api/cases/${id}/image-url`, { cache: "no-store" });
   const imgData = imgRes.ok ? await imgRes.json() : { url: null };
   const createdAtIso = item.created_at ?? null;
+  const isPublic = (item as unknown as { public?: boolean }).public !== false;
   const topViolation = [...(data.violations || [])]
     .sort((a, b) => (Number(b.severity || 0) - Number(a.severity || 0)) || (Number(b.confidence || 0) - Number(a.confidence || 0)))[0];
   const overallConfidence = item.ai_confidence == null ? null : Number(item.ai_confidence);
@@ -73,7 +74,9 @@ export default async function CaseDetailPage({ params }: { params: Promise<{ id:
                 )}
               </p>
             </div>
-            {/* Status badges intentionally omitted for now; to be replaced with ActBlue response status later */}
+            <div className="flex items-center gap-3">
+              <RequestDeletionButton id={id} disabled={!isPublic} />
+            </div>
           </div>
         </div>
 
@@ -117,6 +120,11 @@ export default async function CaseDetailPage({ params }: { params: Promise<{ id:
 
         {/* Extracted text full width */}
         <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-xl shadow-black/5 p-6 md:p-8">
+          {!isPublic && (
+            <div className="mb-4 p-3 rounded-xl bg-yellow-50 border border-yellow-200 text-yellow-900 text-sm">
+              This case is hidden pending deletion review.
+            </div>
+          )}
           <h2 className="text-xl font-semibold text-slate-900 mb-6">Message Content</h2>
           <div className="bg-slate-50 rounded-2xl p-6 max-h-[50vh] overflow-auto">
             <pre className="whitespace-pre-wrap text-slate-700 leading-relaxed font-mono text-sm">

--- a/web/src/server/db/schema.ts
+++ b/web/src/server/db/schema.ts
@@ -59,3 +59,19 @@ export const auditLog = pgTable("audit_log", {
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
 });
 
+export const deletionRequests = pgTable(
+  "deletion_requests",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    submissionId: uuid("submission_id").notNull(),
+    reason: text("reason").notNull(),
+    requester: text("requester"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => {
+    return {
+      submissionIdx: index("deletion_requests_submission_idx").on(table.submissionId),
+    };
+  }
+);
+


### PR DESCRIPTION
- Add deletion_requests table to SQL schema with reason field
- Add deletionRequests to Drizzle schema
- Create POST /api/cases/[id]/request-deletion endpoint
- Add RequestDeletionButton modal component with portal rendering
- Soft-hide cases immediately on deletion request (set public=false)
- Filter cases list to only show public=true cases
- Add hidden banner and disable button for non-public cases
- Log deletion requests to audit_log for transparency
- Redirect to homepage after successful deletion request
- Style improvements: darker text, subtle button, better modal positioning