### PR TITLE
Fixes

### DIFF
--- a/web/src/app/api/inbound-email/route.ts
+++ b/web/src/app/api/inbound-email/route.ts
@@ -44,12 +44,10 @@ export async function POST(req: NextRequest) {
     }
 
     // Use plain text for classification, HTML for display
-    let rawText = bodyPlain || stripHtml(bodyHtml);
-    // Strip top-level forwarded header block if present at the start
-    // Matches lines like: "---------- Forwarded message ---------" and following standard header fields
-    rawText = rawText.replace(/^[-\s>*]+Forwarded message[-\s>*]+\n([\s\S]*?\n){0,10}(?=\n|$)/i, "");
+    const rawText = bodyPlain || stripHtml(bodyHtml);
     
     // Clean text for AI (removes tracking links, invisible chars, excessive whitespace)
+    // Note: cleanTextForAI also strips forwarded message headers
     const cleanedText = cleanTextForAI(rawText);
     
     // Sanitize HTML body (remove non-ActBlue links to protect honeytrap email)

--- a/web/src/app/cases/[id]/client.tsx
+++ b/web/src/app/cases/[id]/client.tsx
@@ -1246,7 +1246,7 @@ type EvidenceTabsProps = {
 export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screenshotUrl, screenshotMime = null, landingImageUrl, landingLink, landingStatus }: EvidenceTabsProps) {
   const redactEmailsInText = (text: string): string => {
     // Extract From: email to preserve it
-    const fromMatch = text.match(/\bFrom:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
+    const fromMatch = text.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
     const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
     
     return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
@@ -1266,7 +1266,7 @@ export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screensh
 
   const redactEmailsInHtml = (html: string): string => {
     // Extract From: email to preserve it
-    const fromMatch = html.match(/\bFrom:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
+    const fromMatch = html.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
     const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
     
     return html.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {

--- a/web/src/server/ingest/html-sanitizer.ts
+++ b/web/src/server/ingest/html-sanitizer.ts
@@ -28,19 +28,19 @@ export function sanitizeEmailHtml(html: string): string {
   
   // Extract From: email to preserve it
   let fromEmail: string | null = null;
-  const fromMatch = sanitized.match(/\bFrom:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
+  const fromMatch = sanitized.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
   if (fromMatch) {
     fromEmail = fromMatch[1];
   }
   
   // Strip names from To: lines and redact the email: "To: Name <email>" => "To: <*******@*******.com>"
-  sanitized = sanitized.replace(/(\bTo:\s*)([^<\n]*?)(<[^>]+>)/gi, (match, prefix, name, angleEmail) => {
+  sanitized = sanitized.replace(/(To:\s*)([^<\n]*?)(<[^>]+>)/gi, (match, prefix, name, angleEmail) => {
     const redactedEmail = angleEmail.replace(emailRegex, maskEmail);
     return `${prefix}${redactedEmail}`;
   });
   
   // Also handle To: without angle brackets: "To: name@example.com" => "To: *******@*******.com"
-  sanitized = sanitized.replace(/(\bTo:\s*)([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/gi, (match, prefix, email) => {
+  sanitized = sanitized.replace(/(To:\s*)([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/gi, (match, prefix, email) => {
     return `${prefix}${maskEmail(email)}`;
   });
   


### PR DESCRIPTION
Commit 1: 45cd1c1 - Fix email redaction and serverless pipeline execution
Made triggerPipelines async with await Promise.all()
Added await triggerPipelines() in inbound routes
Fixed: Vercel serverless was killing fire-and-forget promises
Commit 2: c490de8 - Fix From: email preservation and local development
Detects NODE_ENV=development to force localhost
Fixed: Local dev was calling production API instead of localhost
Commit 3: 6037575 - Fix forwarded header stripping
Removed duplicate broken regex from inbound-email
Fixed: Empty text causing duplicate hash constraint violations
Commit 4: f671bad - Fix From: email extraction (THE CRITICAL ONE)
Removed \b word boundary from From: and To: regex patterns
Fixed: From: email was being masked instead of preserved