### PR TITLE
Strip forwarded headers and redact honeytrap email everywhere

### DIFF
--- a/web/src/app/cases/[id]/client.tsx
+++ b/web/src/app/cases/[id]/client.tsx
@@ -1248,7 +1248,7 @@ export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screensh
   
   const redactEmailsInText = (text: string): string => {
     // First, always redact honeytrap email
-    let result = text.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
+    const result = text.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
     
     // Extract From: email to preserve it
     const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
@@ -1273,7 +1273,7 @@ export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screensh
 
   const redactEmailsInHtml = (html: string): string => {
     // First, always redact honeytrap email
-    let result = html.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
+    const result = html.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
     
     // Extract From: email to preserve it
     const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);

--- a/web/src/app/cases/[id]/client.tsx
+++ b/web/src/app/cases/[id]/client.tsx
@@ -1244,15 +1244,22 @@ type EvidenceTabsProps = {
 };
 
 export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screenshotUrl, screenshotMime = null, landingImageUrl, landingLink, landingStatus }: EvidenceTabsProps) {
+  const HONEYTRAP_EMAIL = "democratdonor@gmail.com";
+  
   const redactEmailsInText = (text: string): string => {
+    // First, always redact honeytrap email
+    let result = text.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
+    
     // Extract From: email to preserve it
-    const fromMatch = text.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
+    const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
     const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
     
-    return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
+    return result.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
       if (fromEmail && email.toLowerCase() === fromEmail) {
         return email; // Preserve From: email
       }
+      // Skip if already redacted
+      if (email.includes('*******')) return email;
       try {
         const parts = email.split("@");
         const domain = parts[1] || "";
@@ -1265,14 +1272,19 @@ export function EvidenceTabs({ caseId, messageType, rawText, emailBody, screensh
   };
 
   const redactEmailsInHtml = (html: string): string => {
+    // First, always redact honeytrap email
+    let result = html.replace(new RegExp(HONEYTRAP_EMAIL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'), '*******@*******.com');
+    
     // Extract From: email to preserve it
-    const fromMatch = html.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
+    const fromMatch = result.match(/From:\s*[^<\n]*?<?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})>?/i);
     const fromEmail = fromMatch ? fromMatch[1].toLowerCase() : null;
     
-    return html.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
+    return result.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, (email) => {
       if (fromEmail && email.toLowerCase() === fromEmail) {
         return email; // Preserve From: email
       }
+      // Skip if already redacted
+      if (email.includes('*******')) return email;
       try {
         const parts = email.split("@");
         const domain = parts[1] || "";


### PR DESCRIPTION
Critical privacy fixes:
1. Strip forwarded message headers from raw_text BEFORE storing in DB
   - Removes '---------- Forwarded message ---------' from preview
   - Applied to both plain text and HTML

2. Specifically redact honeytrap email (democratdonor@gmail.com)
   - Server-side: redact from both rawText and sanitizedHtml
   - Client-side: redact in EvidenceTabs before displaying
   - Uses regex escape to handle special chars in email

3. Preserve From: emails while redacting all others
   - Honeytrap always redacted regardless
   - From: sender email preserved for identification

Result: Honeytrap email and forwarded headers never visible anywhere